### PR TITLE
Set version requirement of pandoc to `>= 1.16`.

### DIFF
--- a/semdoc.cabal
+++ b/semdoc.cabal
@@ -39,7 +39,9 @@ library
     , ghc-paths
     , groom
     , mtl
-    , pandoc                    >= 1.7
+    -- pandoc < 1.16 doesn't write tables in Markdown correctly and doesn't
+    -- respect the 'no-tex-ligatures' option in Markdown.
+    , pandoc                    >= 1.16
     -- pandoc-types-1.17 fails to resolve dependencies correctly.
     , pandoc-types              <= 1.16
     , regex-tdfa

--- a/src/Text/Semdoc/Processor.hs
+++ b/src/Text/Semdoc/Processor.hs
@@ -33,8 +33,7 @@ semdocExtensions =
 
 
 eraseCodeBlocks :: Block -> Block
-eraseCodeBlocks (CodeBlock ("", ["sourceCode", "literate", "haskell"], []) _) =
-  Null
+eraseCodeBlocks (CodeBlock ("", ["sourceCode", "literate", "haskell"], []) _) = Null
 eraseCodeBlocks x = x
 
 


### PR DESCRIPTION
In conjuction with our requirement that pandoc-types is `<= 1.16`, this
effectively means we depend on exactly pandoc 1.16. The reasons for these
restrictions are documented in semdoc.cabal.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/semdoc/5)
<!-- Reviewable:end -->
